### PR TITLE
CRDCDH-298 Enable getUser endpoint

### DIFF
--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -3,5 +3,6 @@ module.exports = Object.freeze({
         NOT_LOGGED_IN: "A user must be logged in to call this API",
         INVALID_USERID: "A userID argument is required to call this API",
         INVALID_ROLE: "You do not have the correct role to perform this operation",
+        NO_ORG_ASSIGNED: "You do not have an organization assigned to your account",
     },
 });

--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -1,0 +1,7 @@
+module.exports = Object.freeze({
+    ERROR: {
+        NOT_LOGGED_IN: "A user must be logged in to call this API",
+        INVALID_USERID: "A userID argument is required to call this API",
+        INVALID_ROLE: "You do not have the correct role to perform this operation",
+    },
+});

--- a/services/user.js
+++ b/services/user.js
@@ -22,12 +22,19 @@ class User {
         if (context?.userInfo?.role !== USER.ROLES.ADMIN && context?.userInfo.role !== USER.ROLES.ORG_OWNER) {
             throw new Error(ERROR.INVALID_ROLE);
         };
+        if (context.userInfo.role === USER.ROLES.ORG_OWNER && !context?.userInfo?.organization?.orgID) {
+            throw new Error(ERROR.NO_ORG_ASSIGNED);
+        }
+
+        const filters = { _id: params.userID };
+        if (context?.userInfo?.role === USER.ROLES.ORG_OWNER) {
+            filters["organization.orgID"] = context?.userInfo?.organization?.orgID;
+        }
 
         const result = await this.userCollection.aggregate([{
-            "$match": {
-                _id: params.userID,
-            }
+            "$match": filters
         }, {"$limit": 1}]);
+
         return (result?.length === 1) ? result[0] : null;
     }
 

--- a/services/user.js
+++ b/services/user.js
@@ -16,13 +16,13 @@ class User {
 
     async getUser(params, context) {
         isLoggedInOrThrow(context);
-        if (!params.userID) {
+        if (!params?.userID) {
             throw new Error(ERROR.INVALID_USERID);
         };
         if (context?.userInfo?.role !== USER.ROLES.ADMIN && context?.userInfo.role !== USER.ROLES.ORG_OWNER) {
             throw new Error(ERROR.INVALID_ROLE);
         };
-        if (context.userInfo.role === USER.ROLES.ORG_OWNER && !context?.userInfo?.organization?.orgID) {
+        if (context?.userInfo?.role === USER.ROLES.ORG_OWNER && !context?.userInfo?.organization?.orgID) {
             throw new Error(ERROR.NO_ORG_ASSIGNED);
         }
 

--- a/services/user.js
+++ b/services/user.js
@@ -1,10 +1,11 @@
 const {getCurrentTimeYYYYMMDDSS} = require("../utility/time-utility");
 const {v4} = require("uuid")
 const {USER} = require("../constants/user-constants");
+const {ERROR} = require("../constants/error-constants");
 const {UpdateProfileEvent} = require("../domain/log-events");
 
 const isLoggedInOrThrow = (context) => {
-    if (!context?.userInfo?.email || !context?.userInfo?.IDP) throw new Error("A user must be logged in to call this API");
+    if (!context?.userInfo?.email || !context?.userInfo?.IDP) throw new Error(ERROR.NOT_LOGGED_IN);
 }
 
 class User {
@@ -13,13 +14,21 @@ class User {
         this.logCollection = logCollection;
     }
 
-    async getUser(userID) {
-        let result = await this.userCollection.aggregate([{
+    async getUser(params, context) {
+        isLoggedInOrThrow(context);
+        if (!params.userID) {
+            throw new Error(ERROR.INVALID_USERID);
+        };
+        if (context?.userInfo?.role !== USER.ROLES.ADMIN && context?.userInfo.role !== USER.ROLES.ORG_OWNER) {
+            throw new Error(ERROR.INVALID_ROLE);
+        };
+
+        const result = await this.userCollection.aggregate([{
             "$match": {
-                _id: userID
+                _id: params.userID,
             }
         }, {"$limit": 1}]);
-        return (result?.length > 0) ? result[0] : null;
+        return (result?.length === 1) ? result[0] : null;
     }
 
     async createNewUser(context) {


### PR DESCRIPTION
### Overview

This PR adds supporting changes to the CRDC database drivers per [CRDCDH-298](https://tracker.nci.nih.gov/browse/CRDCDH-298).

Specifics:

- Add getUser by `_id` query for Admins or Organization Owners
- Results for Org Owners are limited to just users in their organization
- Added the request to the Postman collection (under AuthZ)

> **Note**: There is a related PR upcoming in the AuthZ repo to update the GQL schema and api interface.  