### PR TITLE
CRDCDH-273 listUsers API

### DIFF
--- a/services/user.js
+++ b/services/user.js
@@ -40,10 +40,10 @@ class User {
 
     async listUsers(params, context) {
         isLoggedInOrThrow(context);
-        if (context?.userInfo?.role !== USER.ROLES.ADMIN && context?.userInfo.role !== USER.ROLES.ORG_OWNER) {
+        if (context?.userInfo?.role !== USER.ROLES.ADMIN && context?.userInfo?.role !== USER.ROLES.ORG_OWNER) {
             throw new Error(ERROR.INVALID_ROLE);
         };
-        if (context.userInfo.role === USER.ROLES.ORG_OWNER && !context?.userInfo?.organization?.orgID) {
+        if (context?.userInfo?.role === USER.ROLES.ORG_OWNER && !context?.userInfo?.organization?.orgID) {
             throw new Error(ERROR.NO_ORG_ASSIGNED);
         }
 

--- a/services/user.js
+++ b/services/user.js
@@ -38,6 +38,27 @@ class User {
         return (result?.length === 1) ? result[0] : null;
     }
 
+    async listUsers(params, context) {
+        isLoggedInOrThrow(context);
+        if (context?.userInfo?.role !== USER.ROLES.ADMIN && context?.userInfo.role !== USER.ROLES.ORG_OWNER) {
+            throw new Error(ERROR.INVALID_ROLE);
+        };
+        if (context.userInfo.role === USER.ROLES.ORG_OWNER && !context?.userInfo?.organization?.orgID) {
+            throw new Error(ERROR.NO_ORG_ASSIGNED);
+        }
+
+        const filters = {};
+        if (context?.userInfo?.role === USER.ROLES.ORG_OWNER) {
+            filters["organization.orgID"] = context?.userInfo?.organization?.orgID;
+        }
+
+        const result = await this.userCollection.aggregate([{
+            "$match": filters
+        }]);
+
+        return result || [];
+    }
+
     async createNewUser(context) {
         let sessionCurrentTime = getCurrentTimeYYYYMMDDSS();
         let email = context.userInfo.email;


### PR DESCRIPTION
### Overview

This PR adds supporting changes to the CRDC database drivers per [CRDCDH-273](https://tracker.nci.nih.gov/browse/CRDCDH-273).

Specifics:

- Implements `listUsers` API endpoint with no parameters
- Filters `ORG_OWNER` users to a list of users in their organization ONLY (admins see every user)
- Added the request to Postman (under AuthZ)
- **This is based off of CRDCDH-298** in PR #17 

> **Note**: There is a related PR upcoming in the AuthZ repo to update the api interface.  