### PR TITLE
CRDCDH-274 editUser and listOrganizations 

### DIFF
--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -4,5 +4,9 @@ module.exports = Object.freeze({
         INVALID_USERID: "A userID argument is required to call this API",
         INVALID_ROLE: "You do not have the correct role to perform this operation",
         NO_ORG_ASSIGNED: "You do not have an organization assigned to your account",
+        USER_NOT_FOUND: "The user you are trying to update does not exist",
+        UPDATE_FAILED: "Unknown error occurred while updating object",
+        INVALID_ORG_ID: "The organization ID you provided is invalid",
+        INVALID_ROLE_ASSIGNMENT: "The role you are trying to assign is invalid",
     },
 });

--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -8,5 +8,6 @@ module.exports = Object.freeze({
         UPDATE_FAILED: "Unknown error occurred while updating object",
         INVALID_ORG_ID: "The organization ID you provided is invalid",
         INVALID_ROLE_ASSIGNMENT: "The role you are trying to assign is invalid",
+        USER_ORG_REQUIRED: "An organization is required for the role you are trying to assign",
     },
 });

--- a/services/organization.js
+++ b/services/organization.js
@@ -1,0 +1,71 @@
+const {ERROR} = require("../constants/error-constants");
+const {USER} = require("../constants/user-constants");
+
+class Organization {
+  constructor(organizationCollection) {
+      this.organizationCollection = organizationCollection;
+  }
+
+  async getOrganizationByID(id) {
+      const result = await this.organizationCollection.aggregate([{
+          "$match": { _id: id }
+      }, {"$limit": 1}]);
+      return result?.length > 0 ? result[0] : null;
+  }
+
+  async assignUserToOrganization(orgID, user, role) {
+      const org = await this.getOrganizationByID(orgID);
+      if (!org) {
+          throw new Error(ERROR.INVALID_ORG_ID);
+      }
+
+      if (user.organization?.orgID) {
+          await this.unassignUserFromOrganization(user.organization.orgID, user);
+      }
+
+      const pushBy = {};
+      if (role === USER.ROLES.ORG_OWNER) {
+          pushBy["owners"] = user._id;
+      } else if (role === USER.ROLES.SUBMITTER) {
+          pushBy["submitters"] = {
+            userID: user._id,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            createdAt: user.createdAt,
+            updateAt: user.updateAt,
+          };
+      } else {
+          throw new Error(ERROR.INVALID_ROLE_ASSIGNMENT);
+      }
+
+      const result = await this.organizationCollection.update({ _id: orgID }, { $push: { ...pushBy } });
+      if (result?.modifiedCount !== 1) {
+        throw new Error(ERROR.UPDATE_FAILED);
+      }
+
+      return await this.getOrganizationByID(orgID);
+  }
+
+  async unassignUserFromOrganization(orgID, { _id, role }) {
+      const org = await this.getOrganizationByID(orgID);
+      if (!org) {
+          return true;
+      }
+
+      const pullBy = {};
+      if (role === USER.ROLES.ORG_OWNER) {
+          pullBy["owners"] = _id;
+      } else if (role === USER.ROLES.SUBMITTER) {
+          pullBy["submitters"] = { userID: _id };
+      } else {
+          throw new Error(ERROR.INVALID_ROLE_ASSIGNMENT);
+      }
+
+      const result = await this.organizationCollection.update({ _id: orgID }, { $pull: { ...pullBy } });
+      return result?.modifiedCount === 1;
+  }
+}
+
+module.exports = {
+  Organization
+};

--- a/services/organization.js
+++ b/services/organization.js
@@ -13,6 +13,10 @@ class Organization {
       return result?.length > 0 ? result[0] : null;
   }
 
+  async listOrganizations(filters) {
+    return await this.organizationCollection.aggregate([{ "$match": filters }]);
+  }
+
   async assignUserToOrganization(orgID, user, role) {
       const org = await this.getOrganizationByID(orgID);
       if (!org) {

--- a/services/organization.js
+++ b/services/organization.js
@@ -16,58 +16,6 @@ class Organization {
   async listOrganizations(filters) {
     return await this.organizationCollection.aggregate([{ "$match": filters }]);
   }
-
-  async assignUserToOrganization(orgID, user, role) {
-      const org = await this.getOrganizationByID(orgID);
-      if (!org) {
-          throw new Error(ERROR.INVALID_ORG_ID);
-      }
-
-      if (user.organization?.orgID) {
-          await this.unassignUserFromOrganization(user.organization.orgID, user);
-      }
-
-      const pushBy = {};
-      if (role === USER.ROLES.ORG_OWNER) {
-          pushBy["owners"] = user._id;
-      } else if (role === USER.ROLES.SUBMITTER) {
-          pushBy["submitters"] = {
-            userID: user._id,
-            firstName: user.firstName,
-            lastName: user.lastName,
-            createdAt: user.createdAt,
-            updateAt: user.updateAt,
-          };
-      } else {
-          throw new Error(ERROR.INVALID_ROLE_ASSIGNMENT);
-      }
-
-      const result = await this.organizationCollection.update({ _id: orgID }, { $push: { ...pushBy } });
-      if (result?.modifiedCount !== 1) {
-        throw new Error(ERROR.UPDATE_FAILED);
-      }
-
-      return await this.getOrganizationByID(orgID);
-  }
-
-  async unassignUserFromOrganization(orgID, { _id, role }) {
-      const org = await this.getOrganizationByID(orgID);
-      if (!org) {
-          return true;
-      }
-
-      const pullBy = {};
-      if (role === USER.ROLES.ORG_OWNER) {
-          pullBy["owners"] = _id;
-      } else if (role === USER.ROLES.SUBMITTER) {
-          pullBy["submitters"] = { userID: _id };
-      } else {
-          throw new Error(ERROR.INVALID_ROLE_ASSIGNMENT);
-      }
-
-      const result = await this.organizationCollection.update({ _id: orgID }, { $pull: { ...pullBy } });
-      return result?.modifiedCount === 1;
-  }
 }
 
 module.exports = {

--- a/services/user.js
+++ b/services/user.js
@@ -217,7 +217,7 @@ class User {
                 orgID: newOrg._id,
                 orgName: newOrg.name,
                 createdAt: newOrg.createdAt,
-                updatedAt: newOrg.updatedAt,
+                updateAt: newOrg.updateAt,
             };
         } else if (!params.organization && user[0]?.organization?.orgID) {
             updatedUser.organization = null;

--- a/services/user.js
+++ b/services/user.js
@@ -27,7 +27,7 @@ class User {
 
         const filters = {};
         if (context?.userInfo?.role === USER.ROLES.ORG_OWNER) {
-            filters["organization.orgID"] = context?.userInfo?.organization?.orgID;
+            filters["_id"] = context?.userInfo?.organization?.orgID;
         }
 
         const data = await this.organizationService.listOrganizations(filters);


### PR DESCRIPTION
### Overview

This PR introduces functionality to support the `editUser` and `listOrganizations` mutation and query (respective). 

General implementation notes:

- `editUser` is limited to Admins ONLY
- `editUser` uses the existing `Update_Profile` event log and captures explicitly fields that were saved to the DB
- ~~`editUser` supports only MVP-1 roles (i.e. not Curator) for organization assignment~~ No longer relevant
- `listOrganizations` wraps the Organization Service's version of the function to return the `[OrgInfo]` type
- For Org Owners, `listOrganizations` should only return their own organization

The CRDC postman collection includes both requests.