### PR TITLE
CRDCDH-352 Update listOrganizations

### DIFF
--- a/constants/organization-constants.js
+++ b/constants/organization-constants.js
@@ -1,0 +1,8 @@
+module.exports = Object.freeze({
+    ORGANIZATION: {
+        STATUSES: {
+            ACTIVE: "Active",
+            INACTIVE: "Inactive",
+        },
+    },
+});

--- a/services/organization.js
+++ b/services/organization.js
@@ -1,3 +1,6 @@
+const {ERROR} = require("../constants/error-constants");
+const {USER} = require("../constants/user-constants");
+
 class Organization {
   constructor(organizationCollection) {
       this.organizationCollection = organizationCollection;
@@ -10,7 +13,44 @@ class Organization {
       return result?.length > 0 ? result[0] : null;
   }
 
-  async listOrganizations(filters) {
+  /**
+   * List Organizations API Interface.
+   *
+   * - `ADMIN` and `ORG_OWNER can call this API
+   * - `ORG_OWNER` is limited to only their organization
+   *
+   * @api
+   * @param {Object} params Endpoint parameters
+   * @param {{ cookie: Object, userInfo: Object }} context request context
+   * @returns {Promise<Object[]>} An array of Organizations
+   */
+  async listOrganizationsAPI(params, context) {
+    if (!context?.userInfo?.email || !context?.userInfo?.IDP) {
+        throw new Error(ERROR.NOT_LOGGED_IN)
+    }
+    if (context?.userInfo?.role !== USER.ROLES.ADMIN && context?.userInfo.role !== USER.ROLES.ORG_OWNER) {
+        throw new Error(ERROR.INVALID_ROLE);
+    }
+    if (context.userInfo.role === USER.ROLES.ORG_OWNER && !context?.userInfo?.organization?.orgID) {
+        throw new Error(ERROR.NO_ORG_ASSIGNED);
+    }
+
+    const filters = {};
+    if (context?.userInfo?.role === USER.ROLES.ORG_OWNER) {
+        filters["_id"] = context?.userInfo?.organization?.orgID;
+    }
+
+    return this.listOrganizations(filters);
+  }
+
+  /**
+   * List organizations by an optional set of filters
+   *
+   * @typedef {Object<string, any>} Filters K:V pairs of filters
+   * @param {Filters} [filters] Filters to apply to the query
+   * @returns {Promise<Object[]>} An array of Organizations
+   */
+  async listOrganizations(filters = []) {
     return await this.organizationCollection.aggregate([{ "$match": filters }]);
   }
 }

--- a/services/user.js
+++ b/services/user.js
@@ -2,7 +2,7 @@ const {USER} = require("../constants/user-constants");
 const {ERROR} = require("../constants/error-constants");
 const {UpdateProfileEvent} = require("../domain/log-events");
 
-const {getCurrentTime, subtractDaysFromNow, toISO} = require("../utility/time-utility");
+const {getCurrentTime, subtractDaysFromNow} = require("../utility/time-utility");
 const {LOGIN} = require("../constants/event-constants");
 const {v4} = require("uuid");
 
@@ -17,34 +17,10 @@ const isValidUserStatus = (userStatus) => {
 }
 
 class User {
-    constructor(userCollection, logCollection, organizationService) {
+    constructor(userCollection, logCollection, organizationCollection) {
         this.userCollection = userCollection;
         this.logCollection = logCollection;
-        this.organizationService = organizationService;
-    }
-
-    // Note: This is a wrapper for the OrgService version which returns OrgInfo instead of Organization
-    async listOrganizations(params, context) {
-        isLoggedInOrThrow(context);
-        if (context?.userInfo?.role !== USER.ROLES.ADMIN && context?.userInfo.role !== USER.ROLES.ORG_OWNER) {
-            throw new Error(ERROR.INVALID_ROLE);
-        }
-        if (context.userInfo.role === USER.ROLES.ORG_OWNER && !context?.userInfo?.organization?.orgID) {
-            throw new Error(ERROR.NO_ORG_ASSIGNED);
-        }
-
-        const filters = {};
-        if (context?.userInfo?.role === USER.ROLES.ORG_OWNER) {
-            filters["_id"] = context?.userInfo?.organization?.orgID;
-        }
-
-        const data = await this.organizationService.listOrganizations(filters);
-        return (data || []).map(org => ({
-            orgID: org._id,
-            orgName: org.name,
-            createdAt: org.createdAt,
-            updateAt: org.updateAt,
-        }));
+        this.organizationCollection = organizationCollection;
     }
 
     async getUserByID(userID) {
@@ -231,7 +207,11 @@ class User {
             throw new Error(ERROR.USER_ORG_REQUIRED);
         }
         if (params.organization && params.organization !== user[0]?.organization?.orgID) {
-            const newOrg = await this.organizationService.getOrganizationByID(params.organization);
+            const result = await this.organizationCollection.aggregate([{
+                "$match": { _id: params.organization }
+            }, {"$limit": 1}]);
+            const newOrg = result?.[0];
+
             if (!newOrg?._id || newOrg?._id !== params.organization) {
                 throw new Error(ERROR.INVALID_ORG_ID);
             }


### PR DESCRIPTION
### Overview

* Moves listOrganizations out of User Service (Because it's no longer a wrapper for `OrgInfo` type)
* Replaces the Organization Service dependency on the User Service with an optional userCollection param
* Remove unused `toISO` import

### Related PRs

Requires AuthZ update – https://github.com/CBIIT/crdc-datahub-authz/pull/31