### PR TITLE
CRDCDH-353 Add `editOrganization` and `listCurators`

### DIFF
--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -9,8 +9,11 @@ module.exports = Object.freeze({
         NO_ORG_ASSIGNED: "You do not have an organization assigned to your account",
         USER_NOT_FOUND: "The user you are trying to update does not exist",
         UPDATE_FAILED: "Unknown error occurred while updating object",
-        INVALID_ORG_ID: "The organization ID you provided is invalid",
         INVALID_ROLE_ASSIGNMENT: "The role you are trying to assign is invalid",
         USER_ORG_REQUIRED: "An organization is required for the role you are trying to assign",
+
+        INVALID_ORG_ID: "The organization ID you provided is invalid",
+        ORG_NOT_FOUND: "The organization you are trying to update does not exist",
+        DUPLICATE_ORG_NAME: "An organization with the same name already exists",
     },
 });

--- a/services/organization.js
+++ b/services/organization.js
@@ -163,7 +163,7 @@ class Organization {
           updatedOrg.status = params.status;
       }
 
-      const updateResult = await this.organizationCollection.update({ _id: params.orgID, ...updatedOrg });
+      const updateResult = await this.organizationCollection.update({ _id: orgID, ...updatedOrg });
       if (updateResult?.matchedCount !== 1) {
           throw new Error(ERROR.UPDATE_FAILED);
       }
@@ -183,7 +183,7 @@ class Organization {
         "$match": { name }
     }, {"$limit": 1}]);
     return result?.length > 0 ? result[0] : null;
-}
+  }
 }
 
 module.exports = {

--- a/services/organization.js
+++ b/services/organization.js
@@ -1,3 +1,8 @@
+const {ERROR} = require("../constants/error-constants");
+const {USER} = require("../constants/user-constants");
+const {ORGANIZATION} = require("../constants/organization-constants");
+const {getCurrentTime} = require("../utility/time-utility");
+
 class Organization {
   constructor(organizationCollection) {
       this.organizationCollection = organizationCollection;
@@ -10,8 +15,64 @@ class Organization {
       return result?.length > 0 ? result[0] : null;
   }
 
+  async getOrganizationByName(name) {
+      const result = await this.organizationCollection.aggregate([{
+          "$match": { name }
+      }, {"$limit": 1}]);
+      return result?.length > 0 ? result[0] : null;
+  }
+
   async listOrganizations(filters) {
     return await this.organizationCollection.aggregate([{ "$match": filters }]);
+  }
+
+  async editOrganization(params, userCollection) {
+      const currentOrg = await this.getOrganizationByID(params.orgID);
+      const updatedOrg = { updateAt: getCurrentTime() };
+      if (!currentOrg) {
+          throw new Error(ERROR.ORG_NOT_FOUND);
+      }
+
+      if (params.name && params.name !== currentOrg.name) {
+          const existingOrg = await this.getOrganizationByName(params.name);
+          if (existingOrg) {
+              throw new Error(ERROR.DUPLICATE_ORG_NAME);
+          }
+          updatedOrg.name = params.name;
+      }
+
+      if (params.conciergeID && params.conciergeID !== currentOrg.conciergeID) {
+          const filters = { _id: params.conciergeID, role: USER.ROLES.CURATOR, userStatus: USER.STATUSES.ACTIVE };
+          const result = await userCollection.aggregate([{ "$match": filters }, { "$limit": 1 }]);
+          const conciergeUser = result?.[0];
+          if (!conciergeUser) {
+              throw new Error(ERROR.INVALID_ROLE_ASSIGNMENT);
+          }
+          updatedOrg.conciergeID = params.conciergeID;
+          updatedOrg.conciergeName = `${conciergeUser.firstName} ${conciergeUser.lastName}`.trim();
+          updatedOrg.conciergeEmail = conciergeUser.email;
+      } else if (!params.conciergeID && currentOrg.conciergeID) {
+          updatedOrg.conciergeID = null;
+          updatedOrg.conciergeName = null;
+          updatedOrg.conciergeEmail = null;
+      }
+
+      if (params.studies && Array.isArray(params.studies)) {
+          updatedOrg.studies = params.studies;
+      } else {
+          updatedOrg.studies = [];
+      }
+
+      if (params.status && Object.values(ORGANIZATION.STATUSES).includes(params.status)) {
+          updatedOrg.status = params.status;
+      }
+
+      const updateResult = await this.organizationCollection.update({ _id: params.orgID, ...updatedOrg });
+      if (updateResult?.matchedCount !== 1) {
+          throw new Error(ERROR.UPDATE_FAILED);
+      }
+
+      return { ...currentOrg, ...updatedOrg };
   }
 }
 

--- a/services/organization.js
+++ b/services/organization.js
@@ -137,7 +137,9 @@ class Organization {
           updatedOrg.name = params.name;
       }
 
-      if (params.conciergeID && params.conciergeID !== currentOrg.conciergeID) {
+      const conciergeProvided = typeof params.conciergeID !== "undefined";
+      // Only update the concierge if it is provided and different from the currently assigned concierge
+      if (conciergeProvided && !!params.conciergeID && params.conciergeID !== currentOrg.conciergeID) {
           const filters = { _id: params.conciergeID, role: USER.ROLES.CURATOR, userStatus: USER.STATUSES.ACTIVE };
           const result = await this.userCollection.aggregate([{ "$match": filters }, { "$limit": 1 }]);
           const conciergeUser = result?.[0];
@@ -147,7 +149,8 @@ class Organization {
           updatedOrg.conciergeID = params.conciergeID;
           updatedOrg.conciergeName = `${conciergeUser.firstName} ${conciergeUser.lastName}`.trim();
           updatedOrg.conciergeEmail = conciergeUser.email;
-      } else if (!params.conciergeID && currentOrg.conciergeID) {
+      // Only remove the concierge if it is purposely set to null and there is a currently assigned concierge
+      } else if (conciergeProvided && !params.conciergeID && !!currentOrg.conciergeID) {
           updatedOrg.conciergeID = null;
           updatedOrg.conciergeName = null;
           updatedOrg.conciergeEmail = null;

--- a/services/organization.js
+++ b/services/organization.js
@@ -84,7 +84,7 @@ class Organization {
    * @param {Filters} [filters] Filters to apply to the query
    * @returns {Promise<Object[]>} An array of Organizations
    */
-  async listOrganizations(filters = []) {
+  async listOrganizations(filters = {}) {
     return await this.organizationCollection.aggregate([{ "$match": filters }]);
   }
 
@@ -113,7 +113,7 @@ class Organization {
   }
 
   /**
-   * List organizations by an optional set of filters
+   * Edit an organization by it's `_id` and a set of parameters
    *
    * @async
    * @typedef {{ orgID: string, name: string, conciergeID: string, studies: Object[], status: string }} EditOrganizationInput

--- a/services/user.js
+++ b/services/user.js
@@ -77,7 +77,34 @@ class User {
         return result || [];
     }
 
-    async listActiveCurators() {
+    /**
+     * List Active Curators API Interface.
+     *
+     * - `ADMIN` can call this API only
+     *
+     * @api
+     * @param {Object} params Endpoint parameters
+     * @param {{ cookie: Object, userInfo: Object }} context API request context
+     * @returns {Promise<Object[]>} An array of Curator Users
+     */
+    async listActiveCuratorsAPI(params, context) {
+        if (!context?.userInfo?.email || !context?.userInfo?.IDP) {
+            throw new Error(ERROR.NOT_LOGGED_IN);
+        }
+        if (context?.userInfo?.role !== USER.ROLES.ADMIN) {
+            throw new Error(ERROR.INVALID_ROLE);
+        };
+
+        return this.getActiveCurators();
+    }
+
+    /**
+     * Get all users with the `CURATOR` role and `ACTIVE` status.
+     *
+     * @async
+     * @returns {Promise<Object[]>} An array of Users
+     */
+    async getActiveCurators() {
         const filters = { role: USER.ROLES.CURATOR, userStatus: USER.STATUSES.ACTIVE };
         const result = await this.userCollection.aggregate([{ "$match": filters }]);
 

--- a/services/user.js
+++ b/services/user.js
@@ -77,6 +77,19 @@ class User {
         return result || [];
     }
 
+    async listActiveCurators() {
+        const filters = { role: USER.ROLES.CURATOR, userStatus: USER.STATUSES.ACTIVE };
+        const result = await this.userCollection.aggregate([{ "$match": filters }]);
+
+        return result?.map((user) => ({
+            userID: user._id,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            createdAt: user.createdAt,
+            updateAt: user.updateAt,
+        })) || [];
+    }
+
     async getAdmin() {
         let result = await this.userCollection.aggregate([{
             "$match": {

--- a/services/user.js
+++ b/services/user.js
@@ -85,7 +85,7 @@ class User {
      * @api
      * @param {Object} params Endpoint parameters
      * @param {{ cookie: Object, userInfo: Object }} context API request context
-     * @returns {Promise<Object[]>} An array of Curator Users
+     * @returns {Promise<Object[]>} An array of Curator Users mapped to the `UserInfo` type
      */
     async listActiveCuratorsAPI(params, context) {
         if (!context?.userInfo?.email || !context?.userInfo?.IDP) {
@@ -95,7 +95,14 @@ class User {
             throw new Error(ERROR.INVALID_ROLE);
         };
 
-        return this.getActiveCurators();
+        const curators = await this.getActiveCurators();
+        return curators?.map((user) => ({
+            userID: user._id,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            createdAt: user.createdAt,
+            updateAt: user.updateAt,
+        })) || [];
     }
 
     /**
@@ -108,13 +115,7 @@ class User {
         const filters = { role: USER.ROLES.CURATOR, userStatus: USER.STATUSES.ACTIVE };
         const result = await this.userCollection.aggregate([{ "$match": filters }]);
 
-        return result?.map((user) => ({
-            userID: user._id,
-            firstName: user.firstName,
-            lastName: user.lastName,
-            createdAt: user.createdAt,
-            updateAt: user.updateAt,
-        })) || [];
+        return result || [];
     }
 
     async getAdmin() {


### PR DESCRIPTION
### Overview

This PR adds support for `editOrganization`, `listActiveCurators`, and `getOrganization` per ticket [CRDCDH-353](https://tracker.nci.nih.gov/browse/CRDCDH-353).

Additional notes:

* This branch is based off of CRDCDH-352 in PR #33 with target MVP-2
* The Postman collection is updated with requests to reflect these new endpoints

### Related PRs

Requires AuthZ update – https://github.com/CBIIT/crdc-datahub-authz/pull/32