### PR TITLE
CRDCDH-389 Require DC_POC organization

### DIFF
--- a/services/user.js
+++ b/services/user.js
@@ -227,7 +227,7 @@ class User {
         }
 
         const updatedUser = { _id: params.userID, updateAt: sessionCurrentTime };
-        if (!params.organization && [USER.ROLES.ORG_OWNER, USER.ROLES.SUBMITTER].includes(params.role)) {
+        if (!params.organization && [USER.ROLES.DC_POC, USER.ROLES.ORG_OWNER, USER.ROLES.SUBMITTER].includes(params.role)) {
             throw new Error(ERROR.USER_ORG_REQUIRED);
         }
         if (params.organization && params.organization !== user[0]?.organization?.orgID) {


### PR DESCRIPTION
### Overview

This PR adds supporting changes to FE/BE ticket [CRDCDH-389](https://tracker.nci.nih.gov/browse/CRDCDH-389). Organization field is now REQUIRED for DC_POC role

Note: There is no AuthZ PR for this change