### PR TITLE
CRDCDH-402 `createOrganization` API functionality

### DIFF
--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -9,6 +9,7 @@ module.exports = Object.freeze({
         NO_ORG_ASSIGNED: "You do not have an organization assigned to your account",
         USER_NOT_FOUND: "The user you are trying to update does not exist",
         UPDATE_FAILED: "Unknown error occurred while updating object",
+        CREATE_FAILED: "Unknown error occurred while creating object",
         INVALID_ROLE_ASSIGNMENT: "The role you are trying to assign is invalid",
         USER_ORG_REQUIRED: "An organization is required for the role you are trying to assign",
         MONGODB_HEALTH_CHECK_FAILED: "The MongoDB health check failed, please see the logs for more information",
@@ -18,5 +19,6 @@ module.exports = Object.freeze({
         INVALID_ORG_ID: "The organization ID you provided is invalid",
         ORG_NOT_FOUND: "The organization you are trying to update does not exist",
         DUPLICATE_ORG_NAME: "An organization with the same name already exists",
+        INVALID_ORG_NAME: "The organization name you provided is invalid",
     },
 });


### PR DESCRIPTION
### Overview

This PR adds support for `createOrganization` [CRDCDH-402](https://tracker.nci.nih.gov/browse/CRDCDH-402).

Additional notes:

* The CRDC-DH postman collection has the `createOrganization` API request added under the `AuthZ` folder
* This branch is based off of CRDCDH-353 with the latest from MVP-2.0.0 merged in, so it may initially show lots of changes.

### Related PRs

Requires drivers update – https://github.com/CBIIT/crdc-datahub-authz/pull/40