### PR TITLE
CRDCDH-458 Support `dataCommons` assignment

### DIFF
--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -11,7 +11,7 @@ module.exports = Object.freeze({
         UPDATE_FAILED: "Unknown error occurred while updating object",
         CREATE_FAILED: "Unknown error occurred while creating object",
         INVALID_ROLE_ASSIGNMENT: "The role you are trying to assign is invalid",
-        USER_ORG_REQUIRED: "An organization is required for the role you are trying to assign",
+        USER_ORG_REQUIRED: "An organization is required for this user role",
         USER_DC_REQUIRED: "One or more Data Commons are required for the role you are trying to assign",
         MONGODB_HEALTH_CHECK_FAILED: "The MongoDB health check failed, please see the logs for more information",
         // Utility

--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -12,7 +12,7 @@ module.exports = Object.freeze({
         CREATE_FAILED: "Unknown error occurred while creating object",
         INVALID_ROLE_ASSIGNMENT: "The role you are trying to assign is invalid",
         USER_ORG_REQUIRED: "An organization is required for this user role",
-        USER_DC_REQUIRED: "One or more Data Commons are required for the role you are trying to assign",
+        USER_DC_REQUIRED: "One or more Data Commons are required for this user role",
         MONGODB_HEALTH_CHECK_FAILED: "The MongoDB health check failed, please see the logs for more information",
         // Utility
         JSON_PARSING: "An error occurred while parsing a string to JSON.",

--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -12,6 +12,7 @@ module.exports = Object.freeze({
         INVALID_ORG_ID: "The organization ID you provided is invalid",
         INVALID_ROLE_ASSIGNMENT: "The role you are trying to assign is invalid",
         USER_ORG_REQUIRED: "An organization is required for the role you are trying to assign",
+        USER_DC_REQUIRED: "One or more Data Commons are required for the role you are trying to assign",
         MONGODB_HEALTH_CHECK_FAILED: "The MongoDB health check failed, please see the logs for more information",
         // Utility
         JSON_PARSING: "An error occurred while parsing a string to JSON."

--- a/services/user.js
+++ b/services/user.js
@@ -252,8 +252,10 @@ class User {
         if (params.status && Object.values(USER.STATUSES).includes(params.status)) {
             updatedUser.userStatus = params.status;
         }
-        const isDC_POC = (updatedUser.role && params.role === USER.ROLES.DC_POC) || (!updatedUser.role && user[0]?.role === USER.ROLES.DC_POC);
-        if (isDC_POC && Array.isArray(params.dataCommons)) {
+        if ((updatedUser.role && params.role === USER.ROLES.DC_POC) || (!updatedUser.role && user[0]?.role === USER.ROLES.DC_POC)) {
+            if (!params.dataCommons || params.dataCommons.length === 0) {
+                throw new Error(ERROR.USER_DC_REQUIRED);
+            }
             updatedUser.dataCommons = params.dataCommons;
         } else {
             updatedUser.dataCommons = [];

--- a/services/user.js
+++ b/services/user.js
@@ -118,6 +118,7 @@ class User {
             userStatus: USER.STATUSES.ACTIVE,
             role: USER.ROLES.USER,
             organization: {},
+            dataCommons: [],
             firstName: context?.userInfo?.firstName || emailName,
             lastName: context.userInfo.lastName,
             createdAt: sessionCurrentTime,
@@ -251,6 +252,13 @@ class User {
         if (params.status && Object.values(USER.STATUSES).includes(params.status)) {
             updatedUser.userStatus = params.status;
         }
+        const isDC_POC = (updatedUser.role && params.role === USER.ROLES.DC_POC) || (!updatedUser.role && user[0]?.role === USER.ROLES.DC_POC);
+        if (isDC_POC && Array.isArray(params.dataCommons)) {
+            updatedUser.dataCommons = params.dataCommons;
+        } else {
+            updatedUser.dataCommons = [];
+        }
+
 
         const updateResult = await this.userCollection.update(updatedUser);
         if (updateResult?.matchedCount === 1) {

--- a/services/user.js
+++ b/services/user.js
@@ -265,7 +265,7 @@ class User {
         }
 
         const updatedUser = { _id: params.userID, updateAt: sessionCurrentTime };
-        if (!params.organization && [USER.ROLES.DC_POC, USER.ROLES.ORG_OWNER, USER.ROLES.SUBMITTER].includes(params.role)) {
+        if (!params.organization && [USER.ROLES.DC_POC, USER.ROLES.ORG_OWNER, USER.ROLES.SUBMITTER].includes(params?.role || user[0]?.role)) {
             throw new Error(ERROR.USER_ORG_REQUIRED);
         }
         if (params.organization && params.organization !== user[0]?.organization?.orgID) {


### PR DESCRIPTION
### Overview

This PR modifies `editUser` per [CRDCDH-458](https://tracker.nci.nih.gov/browse/CRDCDH-458).

Additional notes:

* The CRDC-DH postman collection was updated to include the API changes
* Logic Used:
  * If a User IS or WILL BE a DC_POC:
    *  The dataCommons field is REQUIRED to have >1 assignments
  * If a user will no LONGER BE a DC_POC:
    * The dataCommons field is CLEARED and ignored if provided
* There is no validation on the allowed Data commons provided, this is handled on the FE to avoid maintaining two lists. TBD if we want to enforce this on the backend as well
* Fixes a major logic flaw that allows removal of an organization for users that require one. This issue can only be replicated via direct API usage, not on the FE
  1. Edit the user to Assign a role (e.g. DC_POC, Submitter, Org_Owner) and pick an Organization
  2. Edit the user again without a role (undefined) and set the organization to null/empty
  3. No error is thrown even though the user has no organization for a role that must have one

### Related PRs

Requires drivers update – https://github.com/CBIIT/crdc-datahub-authz/pull/42