### PR TITLE
CRDCDH-402 Prefix Org ID with `/` & Remove duplicate code

### DIFF
--- a/services/organization.js
+++ b/services/organization.js
@@ -236,7 +236,7 @@ class Organization {
 
     if (!!process.env.SUBMISSION_BUCKET && !!newOrg._id) {
         newOrg.bucketName = process.env.SUBMISSION_BUCKET;
-        newOrg.rootPath = `${newOrg._id}/`;
+        newOrg.rootPath = `/${newOrg._id}`;
     } else {
         throw new Error(ERROR.NO_SUBMISSION_BUCKET);
     }

--- a/services/organization.js
+++ b/services/organization.js
@@ -49,19 +49,6 @@ class Organization {
   }
 
   /**
-  * Retrieves an organization from the database by its name.
-  *
-  * @param {string} name - The name of the organization to search for.
-  * @returns {Object|null} - The organization object if found, or null if not found.
-  */
-  async getOrganizationByName(name) {
-      const result = await this.organizationCollection.aggregate([{
-          "$match": { name }
-      }, {"$limit": 1}]);
-      return result?.length > 0 ? result[0] : null;
-  }
-
-  /**
    * List Organizations API Interface.
    *
    * - `ADMIN` and `ORG_OWNER can call this API


### PR DESCRIPTION
### Overview

This PR addresses a bug identified by @mtangmt where the `rootPath` property was incorrectly suffixed by `/` instead of being prefixed by it.

Also removes a duplicate function definition.

The authz submodule will need to be updated.

### Related Tickets

https://tracker.nci.nih.gov/browse/CRDCDH-402