### PR TITLE
CRDCDH-482 Update dependent objects with name change 

### DIFF
--- a/services/user.js
+++ b/services/user.js
@@ -27,11 +27,13 @@ const createToken = (userInfo, token_secret, tokenTimeout)=> {
 }
 
 class User {
-    constructor(userCollection, logCollection, organizationCollection, notificationsService, officialEmail) {
+    constructor(userCollection, logCollection, organizationCollection, notificationsService, submissionsCollection, applicationCollection, officialEmail) {
         this.userCollection = userCollection;
         this.logCollection = logCollection;
         this.organizationCollection = organizationCollection;
         this.notificationsService = notificationsService;
+        this.submissionsCollection = submissionsCollection;
+        this.applicationCollection = applicationCollection;
         this.officialEmail = officialEmail;
     }
 
@@ -256,6 +258,23 @@ class User {
             let error = "there is an error getting the result";
             console.error(error)
             throw new Error(error)
+        }
+
+        // Update all dependent objects only if the User's Name has changed
+        // NOTE: We're not waiting for these async updates to complete before returning the updated User
+        if (updateUser.firstName !== user[0].firstName || updateUser.lastName !== user[0].lastName) {
+            this.submissionsCollection.updateMany(
+                { "submitterID": updateUser._id },
+                { "submitterName": `${updateUser.firstName} ${updateUser.lastName}` }
+            );
+            this.organizationCollection.updateMany(
+                { "conciergeID": updateUser._id },
+                { "conciergeName": `${updateUser.firstName} ${updateUser.lastName}` }
+            );
+            this.applicationCollection.updateMany(
+                { "applicant.applicantID": updateUser._id },
+                { "applicant.applicantName": `${updateUser.firstName} ${updateUser.lastName}` }
+            );
         }
 
         context.userInfo = {


### PR DESCRIPTION
### Overview

This PR modifies the implementation of `updateMyUser` to also change dependent data models when the user's name changes.

Models included:

* Submissions (`submitterName`)
* Organizations (`conciergeName`)
* Applications (`applicant.applicantName`)

Not included:

* Submissions (`concierge`) – Concierge name. No `conciergeID` stored in the object.

### Related PRs

https://github.com/CBIIT/crdc-datahub-authz/pull/50
https://github.com/CBIIT/crdc-datahub-database-drivers/pull/58  – Based off this PR

### Related Tickets

https://tracker.nci.nih.gov/browse/CRDCDH-482