### PR TITLE
CRDCDH-1430 Add ApprovedStudy support for `ORCID`

### DIFF
--- a/domain/approved-studies.js
+++ b/domain/approved-studies.js
@@ -3,7 +3,7 @@ const {v4} = require("uuid");
 const {isUndefined} = require("../../utility/string-util");
 
 class ApprovedStudies {
-    constructor(studyName, studyAbbreviation, dbGaPID, organizationName, controlledAccess) {
+    constructor(studyName, studyAbbreviation, dbGaPID, organizationName, controlledAccess, ORCID) {
         this._id = v4();
         this.studyName = studyName;
         this.studyAbbreviation = studyAbbreviation;
@@ -14,15 +14,17 @@ class ApprovedStudies {
         if (organizationName) {
             this.originalOrg = organizationName;
         }
-
+        if (ORCID) {
+            this.ORCID = ORCID;
+        }
         if (!isUndefined(controlledAccess)) {
             this.controlledAccess = controlledAccess;
         }
         this.createdAt = this.updatedAt = getCurrentTime();
     }
 
-    static createApprovedStudies(studyName, studyAbbreviation, dbGaPID, organization, controlledAccess) {
-        return new ApprovedStudies(studyName, studyAbbreviation, dbGaPID, organization, controlledAccess);
+    static createApprovedStudies(studyName, studyAbbreviation, dbGaPID, organization, controlledAccess, ORCID) {
+        return new ApprovedStudies(studyName, studyAbbreviation, dbGaPID, organization, controlledAccess, ORCID);
     }
 }
 

--- a/services/organization.js
+++ b/services/organization.js
@@ -335,7 +335,8 @@ class Organization {
           _id: study?._id,
           studyName: study?.studyName,
           studyAbbreviation: study?.studyAbbreviation,
-          controlledAccess: study?.controlledAccess
+          controlledAccess: study?.controlledAccess,
+          ORCID: study?.ORCID,
       }));
   }
 }


### PR DESCRIPTION
### Overview

This PR updates the ApprovedStudy creation to add the `ORCID` field

> [!Warning]
> This PR is for the 3.1.0 release, not 3.0.0

### Change Details (Specifics)

- Update ApprovedStudies constructor to support new `ORCID` field (optional string)
- Update `getApprovedStudies` to also include `ORCID` during Organization Study assignment

### Related Ticket(s)

CRDCDH-1430 (BE Task)
