### PR TITLE
CRDCDH-1853 Refactor Organization.studies functionality

### DIFF
--- a/services/organization.js
+++ b/services/organization.js
@@ -333,34 +333,34 @@ class Organization {
     return { ...newOrg };
   }
 
-  /**
-  * Stores approved studies in the organization's collection.
-  *
-  * @param {string} orgID - The organization ID.
-   * @param {object} orgApprovedStudy - The approved study array.
-  * @returns {void}
-  */
-  async storeApprovedStudies(orgID, orgApprovedStudy) {
-      const aOrg = await this.getOrganizationByID(orgID);
-      if (!aOrg || !orgApprovedStudy?._id) {
-          return;
-      }
-      const newStudies = [];
-      const matchingStudy = aOrg?.studies.find((study) => orgApprovedStudy?._id === study?._id);
-      if (!matchingStudy) {
-          newStudies.push({ _id: orgApprovedStudy?._id });
-      }
+    /**
+    * Stores approved studies in the organization's collection.
+    *
+    * @param {string} orgID - The organization ID.
+    * @param {object} studyID - The approved study ID
+    * @returns {Promise<void>}
+    */
+    async storeApprovedStudies(orgID, studyID) {
+        const aOrg = await this.getOrganizationByID(orgID);
+        if (!aOrg || !studyID) {
+            return;
+        }
+        const newStudies = [];
+        const matchingStudy = aOrg?.studies.find((study) => studyID === study?._id);
+        if (!matchingStudy) {
+            newStudies.push({ _id: studyID });
+        }
 
-      if (newStudies.length > 0) {
-          aOrg.studies = aOrg.studies || [];
-          aOrg.studies = aOrg.studies.concat(newStudies);
-          aOrg.updateAt = getCurrentTime();
-          const res = await this.organizationCollection.update(aOrg);
-          if (res?.modifiedCount !== 1) {
-              console.error(ERROR.ORGANIZATION_APPROVED_STUDIES_INSERTION + ` orgID: ${orgID}`);
-          }
-      }
-  }
+        if (newStudies.length > 0) {
+            aOrg.studies = aOrg.studies || [];
+            aOrg.studies = aOrg.studies.concat(newStudies);
+            aOrg.updateAt = getCurrentTime();
+            const res = await this.organizationCollection.update(aOrg);
+            if (res?.modifiedCount !== 1) {
+                console.error(ERROR.ORGANIZATION_APPROVED_STUDIES_INSERTION + ` orgID: ${orgID}`);
+            }
+        }
+    }
 
     /**
      * List Organization IDs by a studyName API.


### PR DESCRIPTION
### Overview

This PR refactors how the BE service stores Studies within Organizations. Per request, instead of storing the ApprovedStudy object, we just do a lookup against the ApprovedStudies collection in order to populate the API with the most recent data.

> [!NOTE]
> For backwards compatibility, we're storing the Organization.studies array as `[{ _id: String! }]` rather than `[_id]`. Going forward, when an organization is saved, we store just the `{ _id: String }` instead of `{ ...ApprovedStudy }`. Since the API will overwrite any other fields in the object, this is likely safe to do.

> [!Warning]
> In order to not modify (and potentially break) a ton of email-based code, the `getOrganizationByID` function will perform a mapping of the ApprovedStudies stored in the `Organization.studies` array **by default**. For new code that does not use any study-based data, I'd strongly recommend specifying `true` for `omitStudies`.

### Change Details (Specifics)

- Update all Organization MongoDB pipelines to include a `$lookup` directive against the ApprovedStudies collection
- Update `storeApprovedStudies` to just store the _id instead of the whole ApprovedStudy object
- Update `getApprovedStudies` to map just the `_id` of the object (this method is used in edit/create org only)
- Minor code reformatting

### Related Ticket(s)

CRDCDH-1853