### PR TITLE
Support nested orderBy in PrismaPagination

### DIFF
--- a/domain/prisma-pagination.js
+++ b/domain/prisma-pagination.js
@@ -5,7 +5,7 @@ class PrismaPagination {
         this._first = first;
         this._offset = offset;
         this._orderBy = orderBy;
-        this._sortDirection = sortDirection || SORT.DESC;
+        this._sortDirection = sortDirection || SORT.ASC;
     }
 
     getPagination() {
@@ -53,7 +53,7 @@ class PrismaPagination {
 
     _getSortDirection() {
         const direction = this._sortDirection?.toLowerCase();
-        return direction === SORT.ASC ? SORT.ASC : SORT.DESC;
+        return direction === SORT.DESC ? SORT.DESC : SORT.ASC;
     }
 }
 

--- a/domain/prisma-pagination.js
+++ b/domain/prisma-pagination.js
@@ -35,6 +35,10 @@ class PrismaPagination {
         // Handle nested sorting (e.g., "organization.name" -> { organization: { name: "ASC" } })
         if (this._orderBy.includes('.')) {
             const parts = this._orderBy.split('.');
+            // Validate: no empty parts (consecutive, leading, or trailing dots)
+            if (parts.some(part => part === "")) {
+                throw new Error(`Invalid orderBy value: "${this._orderBy}". Dot notation cannot contain consecutive, leading, or trailing dots.`);
+            }
             let orderByObj = {};
             let current = orderByObj;
             

--- a/domain/prisma-pagination.js
+++ b/domain/prisma-pagination.js
@@ -5,7 +5,7 @@ class PrismaPagination {
         this._first = first;
         this._offset = offset;
         this._orderBy = orderBy;
-        this._sortDirection = sortDirection || SORT.ASC;
+        this._sortDirection = sortDirection || SORT.DESC;
     }
 
     getPagination() {
@@ -53,7 +53,7 @@ class PrismaPagination {
 
     _getSortDirection() {
         const direction = this._sortDirection?.toLowerCase();
-        return direction === SORT.DESC ? SORT.DESC : SORT.ASC;
+        return direction === SORT.ASC ? SORT.ASC : SORT.DESC;
     }
 }
 

--- a/domain/prisma-pagination.js
+++ b/domain/prisma-pagination.js
@@ -11,7 +11,7 @@ class PrismaPagination {
     getPagination() {
         let pagination = {};
         if (this._orderBy) {
-            pagination.orderBy = {[this._orderBy]: this._getSortDirection()};
+            pagination.orderBy = this._buildOrderBy();
         }
 
         if (this._offset) {
@@ -26,11 +26,34 @@ class PrismaPagination {
     }
 
     getNoLimit() {
-        return (this._orderBy) ? { [this._orderBy]: this._getSortDirection() } : {};
+        return (this._orderBy) ? this._buildOrderBy() : {};
+    }
+
+    _buildOrderBy() {
+        if (!this._orderBy) return {};
+        
+        // Handle nested sorting (e.g., "organization.name" -> { organization: { name: "ASC" } })
+        if (this._orderBy.includes('.')) {
+            const parts = this._orderBy.split('.');
+            let orderByObj = {};
+            let current = orderByObj;
+            
+            for (let i = 0; i < parts.length - 1; i++) {
+                current[parts[i]] = {};
+                current = current[parts[i]];
+            }
+            
+            current[parts[parts.length - 1]] = this._getSortDirection();
+            return orderByObj;
+        }
+        
+        // Handle direct field sorting
+        return { [this._orderBy]: this._getSortDirection() };
     }
 
     _getSortDirection() {
-        return this._sortDirection?.toLowerCase() === SORT.DESC ? SORT.DESC : SORT.ASC;
+        const direction = this._sortDirection?.toLowerCase();
+        return direction === SORT.ASC ? SORT.ASC : SORT.DESC;
     }
 }
 


### PR DESCRIPTION
Added _buildOrderBy method to handle nested sorting fields (e.g., 'organization.name') in PrismaPagination. Updated getPagination and getNoLimit to use the new method. Also fixed _getSortDirection to default to DESC unless ASC is specified.